### PR TITLE
Add one-click start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,13 @@ This project provides a Model Context Protocol (MCP) server for managing LLM con
 - **Tests**: `npm test` for Node, `pytest` for Python
 - **Run local model**: `python run_local.py --model sshleifer/tiny-gpt2 --port 8000`
 - **Streamlit UI**: `streamlit run app.py`
+
+## One-Click Start
+
+To launch both the MCP server and a local model server in one step, run:
+
+```bash
+./start.sh
+```
+
+The script installs missing Node dependencies, builds the server if needed, and then starts the MCP service alongside the local model server. Connection details are printed to the terminal for easy integration with IDEs and tools.

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+# One-click startup script for MCP server and local model
+
+MODEL=${MODEL:-"sshleifer/tiny-gpt2"}
+NODE_PORT=${PORT:-3000}
+MODEL_PORT=${MODEL_PORT:-8000}
+
+# Install Node dependencies if missing
+if [ ! -d node_modules ]; then
+  echo "Installing Node dependencies..."
+  npm install --silent
+fi
+
+# Build TypeScript project if dist is missing
+if [ ! -d dist ]; then
+  echo "Building MCP server..."
+  npm run build --silent
+fi
+
+# Start MCP server
+node dist/index.js &
+NODE_PID=$!
+
+# Start local model server
+python run_local.py --model "$MODEL" --port "$MODEL_PORT" &
+MODEL_PID=$!
+
+# Output connection info
+cat <<INFO
+MCP Server running on http://localhost:$NODE_PORT
+Local model server running on http://localhost:$MODEL_PORT
+Server PIDs: MCP=$NODE_PID, MODEL=$MODEL_PID
+Press Ctrl+C to stop both processes.
+INFO
+
+wait $NODE_PID $MODEL_PID


### PR DESCRIPTION
## Summary
- add `start.sh` to run both Node server and local model server
- document usage in README

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684131d815d4832d9e74934a3c0342cf