### PR TITLE
Add cross-platform launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,12 @@ This project provides a Model Context Protocol (MCP) server for managing LLM con
 To launch both the MCP server and a local model server in one step, run:
 
 ```bash
-./start.sh
+python start.py
 ```
+
+The `start.py` script is cross-platform and installs any missing Node and
+Python dependencies, builds the TypeScript server if necessary, and then starts
+the MCP server alongside the local model server. On Unix-like systems you can
+also use `./start.sh`.
 
 The script installs missing Node dependencies, builds the server if needed, and then starts the MCP service alongside the local model server. Connection details are printed to the terminal for easy integration with IDEs and tools.

--- a/start.py
+++ b/start.py
@@ -1,0 +1,59 @@
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def ensure_node_deps() -> None:
+    """Install Node dependencies if node_modules missing."""
+    if not Path("node_modules").exists():
+        subprocess.check_call(["npm", "install", "--silent"])
+
+
+def ensure_python_deps() -> None:
+    """Install Python dependencies from requirements.txt."""
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "-r", "requirements.txt"])
+
+
+def ensure_build() -> None:
+    """Build TypeScript project if dist directory is missing."""
+    if not Path("dist").exists():
+        subprocess.check_call(["npm", "run", "build", "--silent"])
+
+
+def start_servers(model: str, node_port: int, model_port: int) -> None:
+    """Launch MCP server and local model server."""
+    env = os.environ.copy()
+    env.setdefault("PORT", str(node_port))
+    node_proc = subprocess.Popen(["node", "dist/index.js"], env=env)
+    model_proc = subprocess.Popen([sys.executable, "run_local.py", "--model", model, "--port", str(model_port)])
+
+    print(f"MCP Server running on http://localhost:{node_port}")
+    print(f"Local model server running on http://localhost:{model_port}")
+    print(f"Server PIDs: MCP={node_proc.pid}, MODEL={model_proc.pid}")
+    print("Press Ctrl+C to stop both processes.")
+
+    try:
+        node_proc.wait()
+        model_proc.wait()
+    finally:
+        node_proc.kill()
+        model_proc.kill()
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="One-click launcher for MCP server and local model")
+    parser.add_argument("--model", default="sshleifer/tiny-gpt2")
+    parser.add_argument("--port", type=int, default=3000)
+    parser.add_argument("--model-port", type=int, default=8000)
+    args = parser.parse_args(argv)
+
+    ensure_node_deps()
+    ensure_python_deps()
+    ensure_build()
+    start_servers(args.model, args.port, args.model_port)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -1,0 +1,34 @@
+import sys
+from types import SimpleNamespace
+from pathlib import Path
+import start
+
+
+def test_main_invokes_all(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_check_call(cmd, **kwargs):
+        calls.append(cmd)
+
+    def fake_popen(cmd, **kwargs):
+        calls.append(cmd)
+        class P:
+            pid = 123
+            def wait(self):
+                pass
+            def kill(self):
+                pass
+        return P()
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(start.subprocess, "check_call", fake_check_call)
+    monkeypatch.setattr(start.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(sys, "argv", ["start.py", "--model", "m", "--port", "1", "--model-port", "2"])
+
+    start.main()
+
+    assert ["npm", "install", "--silent"] in calls
+    assert ["npm", "run", "build", "--silent"] in calls
+    assert [sys.executable, "-m", "pip", "install", "-r", "requirements.txt"] in calls
+    assert ["node", "dist/index.js"] in calls
+    assert [sys.executable, "run_local.py", "--model", "m", "--port", "2"] in calls


### PR DESCRIPTION
## Summary
- implement a cross-platform `start.py` launcher
- document it in README
- add test coverage for new script

## Testing
- `pre-commit run --all-files`
- `npm test` *(fails: jest not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684134c4e9c8832d8a586b263e6c3b9a