### PR TITLE
Update README for easier setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,56 @@
 # Void MCP Server
 
-This project provides a Model Context Protocol (MCP) server for managing LLM context data. A small utility `run_local.py` can launch a local Hugging Face model and a Streamlit interface.
+This project provides a Model Context Protocol (MCP) server for storing and retrieving LLM context data. It ships with `run_local.py` for running a lightweight Hugging Face model and `app.py` for a simple Streamlit UI.
 
-## Development
+## Quick Start
 
-- **Install dependencies**
-  - Node: `npm install`
-  - Python: `pip install -r requirements.txt`
-- **Build**: `npm run build`
-- **Tests**: `npm test` for Node, `pytest` for Python
-- **Run local model**: `python run_local.py --model sshleifer/tiny-gpt2 --port 8000`
-- **Streamlit UI**: `streamlit run app.py`
+1. **Install prerequisites**
+   - Node.js and npm
+   - Python 3.11
+   - PostgreSQL (ensure the service is running)
 
-## One-Click Start
+2. **Install dependencies**
+   ```bash
+   npm install          # Node packages
+   pip install -r requirements.txt
+   ```
 
-To launch both the MCP server and a local model server in one step, run:
+3. **Configure the database**
 
-```bash
-python start.py
-```
+   Create a `.env` file in the project root and set at least the following variables:
+   ```env
+   DATABASE_HOST=localhost
+   DATABASE_PORT=5432
+   DATABASE_NAME=llm_context_db
+   DATABASE_USER=your_db_user
+   DATABASE_PASSWORD=your_db_password  # must be a string
+   PORT=3000
+   JWT_SECRET=change-me-in-production-min-32-chars
+   ```
+   If `DATABASE_PASSWORD` is missing you will see the error:
+   `SASL: SCRAM-SERVER-FIRST-MESSAGE: client password must be a string`.
 
-The `start.py` script is cross-platform and installs any missing Node and
-Python dependencies, builds the TypeScript server if necessary, and then starts
-the MCP server alongside the local model server. On Unix-like systems you can
-also use `./start.sh`.
+4. **Build the server**
+   ```bash
+   npm run build
+   ```
 
-The script installs missing Node dependencies, builds the server if needed, and then starts the MCP service alongside the local model server. Connection details are printed to the terminal for easy integration with IDEs and tools.
+5. **Run everything**
+   ```bash
+   python start.py
+   ```
+   The MCP API will be available at `http://localhost:3000` and the local model server at `http://localhost:8000`. Press `Ctrl+C` to stop them.
+
+6. **Optional: Launch the Streamlit interface**
+   ```bash
+   streamlit run app.py
+   ```
+
+## Development Tips
+
+- Run tests with `pytest` and `npm test`.
+- Start only the local model using `python run_local.py --model sshleifer/tiny-gpt2 --port 8000`.
+- Format and lint with `pre-commit run --all-files`.
+- `setup.sh` provides an interactive database setup if you need it.
+
+


### PR DESCRIPTION
## Summary
- rewrite README with clear quick-start steps
- include example `.env` variables and error explanation

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68413e3fc78c832d9ada8fd68789b757