### PR TITLE
Add IDE config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,28 @@ the MCP server alongside the local model server. On Unix-like systems you can
 also use `./start.sh`.
 
 The script installs missing Node dependencies, builds the server if needed, and then starts the MCP service alongside the local model server. Connection details are printed to the terminal for easy integration with IDEs and tools.
+
+## IDE Integration
+
+To connect your IDE's context features to the MCP server, provide a configuration file like `ide_config.json` pointing to `start.py` in this repository.
+
+Replace `/path/to/Void-MCP-Server/start.py` with the absolute path on your system:
+
+```json
+{
+  "context_servers": {
+    "my-mcp-server": {
+      "command": {
+        "path": "python",
+        "args": [
+          "/path/to/Void-MCP-Server/start.py"
+        ],
+        "env": {}
+      },
+      "settings": {}
+    }
+  }
+}
+```
+
+Run `python start.py --help` for available options such as `--model`, `--port`, and `--model-port` to customize the servers.

--- a/ide_config.example.json
+++ b/ide_config.example.json
@@ -1,0 +1,14 @@
+{
+  "context_servers": {
+    "my-mcp-server": {
+      "command": {
+        "path": "python",
+        "args": [
+          "/path/to/Void-MCP-Server/start.py"
+        ],
+        "env": {}
+      },
+      "settings": {}
+    }
+  }
+}

--- a/tests/test_ide_config.py
+++ b/tests/test_ide_config.py
@@ -1,0 +1,12 @@
+import json
+from pathlib import Path
+
+
+def test_example_config_valid():
+    path = Path("ide_config.example.json")
+    data = json.loads(path.read_text())
+    assert "context_servers" in data
+    name, server = next(iter(data["context_servers"].items()))
+    command = server["command"]
+    assert command["path"] == "python"
+    assert command["args"] and command["args"][0].endswith("start.py")


### PR DESCRIPTION
## Summary
- document basic IDE integration
- provide `ide_config.example.json`
- test sample IDE config loads

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68413f122bd8832db9555d0efe35332e